### PR TITLE
fix: deprecated fs function

### DIFF
--- a/consumer-server/src/logic/message-handler.ts
+++ b/consumer-server/src/logic/message-handler.ts
@@ -34,7 +34,7 @@ export function createMessageHandlerComponent({
 
     const filesToUpload = result.lodsFiles.concat(result.logFile)
     await storage.storeFiles(filesToUpload, base, message.entity.entityTimestamp.toString())
-    fs.rmdirSync(result.outputPath, { recursive: true })
+    fs.rmSync(result.outputPath, { recursive: true })
   }
 
   return { handle }


### PR DESCRIPTION
This PR prevents the following warning:
`DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead`