### PR TITLE
fix: scene naming fbx exporter

### DIFF
--- a/DCL_PiXYZ/PXZEntryPoint.cs
+++ b/DCL_PiXYZ/PXZEntryPoint.cs
@@ -23,13 +23,13 @@ namespace DCL_PiXYZ
 
         private static async Task RunLODBuilder(string[] args)
         {
-            string defaultScene = "5,19";
+            string defaultScene = "23,-34";
             string defaultOutputPath = Path.Combine(Directory.GetCurrentDirectory(), "built-lods") ;
             string defaultSceneLodManifestDirectory = Path.Combine(Directory.GetCurrentDirectory(), "scene-lod-entities-manifest-builder/");
 
             bool isDebug = true;
             bool installNPM = true;
-            string decimationValues = "7000;3000;1000;500";
+            string decimationValues = "7000;500";
             int startingLODLevel = 0;
 
 
@@ -64,7 +64,7 @@ namespace DCL_PiXYZ
             {
                 if (IsRoad(roadCoordinates, currentScene)) continue;
 
-                if (HasSceneBeenAnalyzed(convertedScenes, currentScene)) continue;
+                if (HasSceneBeenConverted(convertedScenes, currentScene)) continue;
 
                 sceneConversionInfo.SceneImporter = new SceneImporter(sceneConversionInfo.ConversionType, currentScene, sceneConversionInfo.WebRequestsHandler);
                 if (!await SceneDefinitionDownloadSuccesfully(sceneConversionInfo, currentScene, pathHandler)) continue;
@@ -190,19 +190,6 @@ namespace DCL_PiXYZ
             return false;
         }
 
-        private static bool HasSceneBeenAnalyzed(List<string> analyzedScenes, string scene)
-        {
-            //Check if the scene has already been analyzed (for bulk conversion)
-            if (analyzedScenes.Contains(scene))
-            {
-                FileWriter.WriteToConsole($"Scene {scene} has already been analyzed");
-                return true;
-            }
-
-            return false;
-        }
-
-
         private static async Task<bool> GenerateManifest(string sceneType, string sceneValue, string sceneManifestDirectory, List<string> errorsToIgnore, string failFile)
         {
             FileWriter.WriteToConsole($"BEGIN MANIFEST GENERATION FOR SCENE {sceneValue}");
@@ -233,7 +220,11 @@ namespace DCL_PiXYZ
             modifiers.Add(new PXZBeginCleanMaterials());
             modifiers.Add(new PXZRepairMesh(models));
             
-            if (pxzParams.LodLevel != 0)
+            if (pxzParams.LodLevel == 0)
+            {
+                modifiers.Add(new PXZMaterialNameRandomizer());
+            }
+            else
             {
                 modifiers.Add(new PXZDeleteByName(".*collider.*"));
                 modifiers.Add(new PXZDecimator(sceneConversionInfo.SceneImporter.GetSceneBasePointer(), pxzParams.DecimationType,
@@ -310,7 +301,7 @@ namespace DCL_PiXYZ
 
         private static void CreateDirectories(SceneConversionInfo sceneConversionInfo)
         {
-            Directory.CreateDirectory(PXYZConstants.RESOURCES_DIRECTORY);
+            Directory.CreateDirectory(PXZConstants.RESOURCES_DIRECTORY);
         }
 
 

--- a/DCL_PiXYZ/PiXYZWorflow/PXZBeginCleanMaterials.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZBeginCleanMaterials.cs
@@ -13,11 +13,11 @@ namespace DCL_PiXYZ
     public class PXZBeginCleanMaterials : IPXZModifier
     {
 
-        private Dictionary<string, uint> materialDictionary;
+
 
         public PXZBeginCleanMaterials()
         {
-            materialDictionary = new Dictionary<string, uint>();
+
         }
         
         public async Task ApplyModification(PiXYZAPI pxz)

--- a/DCL_PiXYZ/PiXYZWorflow/PXZConstants.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZConstants.cs
@@ -3,7 +3,7 @@ using DCL_PiXYZ.SceneRepositioner.JsonParsing;
 
 namespace DCL_PiXYZ
 {
-    public class PXYZConstants
+    public class PXZConstants
     {
         public static string RESOURCES_DIRECTORY = Path.Combine(Directory.GetCurrentDirectory(), "Resources");
 
@@ -14,7 +14,8 @@ namespace DCL_PiXYZ
         public static string HASH_PARAM = "hash";
         
         public static string CUSTOM_MATERIAL_CONVERTED = "CUSTOM_MATERIAL";
-
-
+        
+        public static string FORCED_TRANSPARENT_MATERIAL = "FORCED_TRANSPARENT";
+        public static string OPAQUE_MATERIAL = "OPAQUE";
     }
 }

--- a/DCL_PiXYZ/PiXYZWorflow/PXZMaterialNameRandomizer.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZMaterialNameRandomizer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using UnityEngine.Pixyz.API;
+using UnityEngine.Pixyz.Material;
+using UnityEngine.Pixyz.Scene;
+
+namespace DCL_PiXYZ
+{
+    public class PXZMaterialNameRandomizer : IPXZModifier
+    {
+        public async Task ApplyModification(PiXYZAPI pxz)
+        {
+            pxz.Scene.MergeImages();
+            PackedTree packedTree = pxz.Scene.GetSubTree(pxz.Scene.GetRoot());
+            for (var i = 0; i < packedTree.occurrences.list.Length; i++)
+            {
+                if (pxz.Scene.HasComponent(packedTree.occurrences[i], ComponentType.Part) && !packedTree.names[i].Contains("collider"))
+                {
+                    MaterialList material = pxz.Scene.GetMaterialsFromSubtree(packedTree.occurrences[i]);
+                    for (var j = 0; j < material.list.Length; j++)
+                    {
+                        Random random = new Random();
+                        string nameToSet = random.Next(0, 1000).ToString();
+                        string currentName = pxz.Core.GetProperty(material.list[j], "Name");
+                        if (currentName.Contains(PXZConstants.FORCED_TRANSPARENT_MATERIAL))
+                            nameToSet += PXZConstants.FORCED_TRANSPARENT_MATERIAL;
+                        pxz.Core.SetProperty(material.list[j], "Name", nameToSet);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/DCL_PiXYZ/PiXYZWorflow/PXZMergeMeshes.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZMergeMeshes.cs
@@ -101,7 +101,7 @@ namespace DCL_PiXYZ
 
             
             uint combineMeshes = pxz.Algo.CombineMeshes(toMerge, bakeOption);
-            pxz.Core.SetProperty(combineMeshes, "Name", $"MERGED MESH {index} {(isOpaque ? "OPAQUE" : "FORCED_TRANSPARENT")}");
+            pxz.Core.SetProperty(combineMeshes, "Name", $"MERGED MESH {index} {(isOpaque ? PXZConstants.OPAQUE_MATERIAL : PXZConstants.FORCED_TRANSPARENT_MATERIAL)}");
 
             FileWriter.WriteToConsole("Copying Material");
             //Apply a copy of the material not to lose the reference
@@ -110,7 +110,7 @@ namespace DCL_PiXYZ
             if (material.list?.Length > 0)
             {
                 uint copyMaterial = pxz.Material.CopyMaterial(material.list[0], false);
-                pxz.Core.SetProperty(copyMaterial, "Name", $"MERGE MATERIAL {index} {(isOpaque ? "OPAQUE" : "FORCED_TRANSPARENT")}");
+                pxz.Core.SetProperty(copyMaterial, "Name", $"MERGE MATERIAL {index} {(isOpaque ? PXZConstants.OPAQUE_MATERIAL : PXZConstants.FORCED_TRANSPARENT_MATERIAL)}");
                 pxz.Scene.SetOccurrenceMaterial(combineMeshes,copyMaterial);
                 FileWriter.WriteToConsole("Setting Material");
             }
@@ -130,7 +130,7 @@ namespace DCL_PiXYZ
                     {
                         MaterialList material = pxz.Scene.GetMaterialsFromSubtree(packedTreeOccurrence);
                         //A material will be consider transparent only if it has a single material and its name contains "FORCED_TRANSPARENT" added during the material curation
-                        bool isTransparent = material.list.Length == 1 && pxz.Core.GetProperty(material.list[0], "Name").Contains("FORCED_TRANSPARENT");
+                        bool isTransparent = material.list.Length == 1 && pxz.Core.GetProperty(material.list[0], "Name").Contains(PXZConstants.FORCED_TRANSPARENT_MATERIAL);
                         if (isTransparent)
                             transparentsToMerge.AddOccurrence(packedTreeOccurrence);
                         else

--- a/DCL_PiXYZ/SceneImporter/SceneImporter.cs
+++ b/DCL_PiXYZ/SceneImporter/SceneImporter.cs
@@ -32,7 +32,7 @@ namespace DCL_PiXYZ
             this.sceneParam = sceneParam;
             this.webRequestsHandler = webRequestsHandler;
 
-            paramByHash = paramType.Equals(PXYZConstants.HASH_PARAM);
+            paramByHash = paramType.Equals(PXZConstants.HASH_PARAM);
 
             ignoreExtensions = new []{".mp3", ".js", ".lib", ".json", ".md", ".wav"};
             contentsURL = "https://peer.decentraland.org/content/contents/";
@@ -92,7 +92,7 @@ namespace DCL_PiXYZ
                 {
                     if (ignoreExtensions.Contains(Path.GetExtension(content.file)))
                         continue;
-                    string filePath = Path.Combine(PXYZConstants.RESOURCES_DIRECTORY, content.file);
+                    string filePath = Path.Combine(PXZConstants.RESOURCES_DIRECTORY, content.file);
                     await webRequestsHandler.DownloadFileAsync($"{contentsURL}{content.hash}", filePath);
                     sceneContent.Add(content.file.ToLower(), filePath);
                 }

--- a/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLGLTFMesh.cs
+++ b/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLGLTFMesh.cs
@@ -34,7 +34,7 @@ namespace AssetBundleConverter.LODs
             if (!contentTable.TryGetValue(src.ToLower(), out string modelPath))
             {
                 LogError($"ERROR: GLTF {src} file not found in sceneContent");
-                return PXYZConstants.EMPTY_MODEL;
+                return PXZConstants.EMPTY_MODEL;
             }
 
             bool modelRecreatedSuccessfully = true;
@@ -59,7 +59,7 @@ namespace AssetBundleConverter.LODs
             catch (Exception e)
             {
                 FileWriter.WriteToConsole($"ERROR: Importing GLTF {src} failed with error {e}");
-                return PXYZConstants.EMPTY_MODEL;
+                return PXZConstants.EMPTY_MODEL;
             }
         }
 
@@ -69,8 +69,8 @@ namespace AssetBundleConverter.LODs
             var model = ModelRoot.Load(modelPath, readSettings);
             foreach (var gltfMaterial in model.LogicalMaterials)
             {
-                if (gltfMaterial.Alpha != AlphaMode.OPAQUE && !gltfMaterial.Name.Contains("FORCED_TRANSPARENT"))
-                    gltfMaterial.Name += "FORCED_TRANSPARENT";
+                if (gltfMaterial.Alpha != AlphaMode.OPAQUE && !gltfMaterial.Name.Contains(PXZConstants.FORCED_TRANSPARENT_MATERIAL))
+                    gltfMaterial.Name += PXZConstants.FORCED_TRANSPARENT_MATERIAL;
             }
 
             SaveModel(model, modelPath);

--- a/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLMaterial.cs
+++ b/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLMaterial.cs
@@ -30,7 +30,7 @@ namespace DCL_PiXYZ.SceneRepositioner.SceneBuilder.Entities
 
         public uint GetMaterial(PiXYZAPI pxz, string entityID, Dictionary<string, string> contentTable)
         {
-            uint material = pxz.Material.CreateMaterial($"{PXYZConstants.CUSTOM_MATERIAL_CONVERTED}_{entityID}" , "PBR");
+            uint material = pxz.Material.CreateMaterial($"{PXZConstants.CUSTOM_MATERIAL_CONVERTED}_{entityID}" , "PBR");
             ColorOrTexture albedoColorOrTexture = new ColorOrTexture();
             if (texture?.tex?.src != null)
             {

--- a/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLPrimitiveMesh.cs
+++ b/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLPrimitiveMesh.cs
@@ -37,7 +37,7 @@ namespace DCL_PiXYZ.SceneRepositioner.SceneBuilder.Entities
         protected override uint GetMesh(PiXYZAPI pxz, string entityID)
         {
             string boxCreated = BoxFactory.Create(entityID, uvs);
-            return pxz.IO.ImportScene(Path.Combine(PXYZConstants.RESOURCES_DIRECTORY, boxCreated));
+            return pxz.IO.ImportScene(Path.Combine(PXZConstants.RESOURCES_DIRECTORY, boxCreated));
         }
 
     }
@@ -50,7 +50,7 @@ namespace DCL_PiXYZ.SceneRepositioner.SceneBuilder.Entities
         protected override uint GetMesh(PiXYZAPI pxz, string entityID)
         {
             string cylinderCreated = CylinderVariantsFactory.Create(entityID, radiusTop, radiusBottom);
-            return pxz.IO.ImportScene(Path.Combine(PXYZConstants.RESOURCES_DIRECTORY, cylinderCreated));
+            return pxz.IO.ImportScene(Path.Combine(PXZConstants.RESOURCES_DIRECTORY, cylinderCreated));
         }
     }
 
@@ -61,7 +61,7 @@ namespace DCL_PiXYZ.SceneRepositioner.SceneBuilder.Entities
         protected override uint GetMesh(PiXYZAPI pxz, string entityID)
         {
             string planeCreated = PlaneFactory.Create(entityID, uvs);
-            return pxz.IO.ImportScene(Path.Combine(PXYZConstants.RESOURCES_DIRECTORY, planeCreated));
+            return pxz.IO.ImportScene(Path.Combine(PXZConstants.RESOURCES_DIRECTORY, planeCreated));
         }
     }
 
@@ -70,7 +70,7 @@ namespace DCL_PiXYZ.SceneRepositioner.SceneBuilder.Entities
         protected override uint GetMesh(PiXYZAPI pxz, string entityID)
         {
             string sphereCreated = SphereFactory.Create(entityID);
-            return pxz.IO.ImportScene(Path.Combine(PXYZConstants.RESOURCES_DIRECTORY, sphereCreated));
+            return pxz.IO.ImportScene(Path.Combine(PXZConstants.RESOURCES_DIRECTORY, sphereCreated));
         }
     }
     

--- a/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLRendereableEntity.cs
+++ b/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLRendereableEntity.cs
@@ -58,7 +58,7 @@ namespace DCL_PiXYZ.SceneRepositioner.SceneBuilder.Entities
                 return rendereableMesh.InstantiateMesh(pxz, entityID.ToString(), instantiatedEntity, material, contentTable, pathHandler);
             }
             else
-                return PXYZConstants.EMPTY_MODEL;
+                return PXZConstants.EMPTY_MODEL;
         }
 
         private void InstantiateTransform(Dictionary<int, DCLRendereableEntity> renderableEntities)

--- a/DCL_PiXYZ/SceneRepositioner/SceneBuilder/PrimitiveFactory/OBJExporter.cs
+++ b/DCL_PiXYZ/SceneRepositioner/SceneBuilder/PrimitiveFactory/OBJExporter.cs
@@ -9,7 +9,7 @@ namespace DCL_PiXYZ.SceneRepositioner.SceneBuilder.PrimitiveFactory
         public static void CreateOBJFile(string filePath, int verticesNum, int trisNum, Vector3[] vertices, int[] tris, Vector3[] normals, Vector2[] customUvs)
         {
             var objContent = CreateOBJContent(verticesNum, trisNum, vertices, tris, normals, customUvs);
-            File.WriteAllText(Path.Combine(PXYZConstants.RESOURCES_DIRECTORY, filePath), objContent);
+            File.WriteAllText(Path.Combine(PXZConstants.RESOURCES_DIRECTORY, filePath), objContent);
         }
 
         private static string CreateOBJContent(int verticesNum, int trisNum, Vector3[] vertices, int[] tris, Vector3[] normals, Vector2[] uvs)

--- a/DCL_PiXYZ/Utils/ManifestWorldBuilder.cs
+++ b/DCL_PiXYZ/Utils/ManifestWorldBuilder.cs
@@ -26,8 +26,8 @@ namespace DCL_PiXYZ.Utils
             //UNCOMMENT IF YOU NEED TO INSTALL
             //NPMUtils.DoNPMInstall(sceneManifestDirectory);
             
-            string sourcePath = Path.Combine(PXYZConstants.RESOURCES_DIRECTORY, "non-empty-scenes.txt"); // Replace with the path to your source file
-            string destinationPath = Path.Combine(PXYZConstants.RESOURCES_DIRECTORY, "manifest-world-builder-results.txt"); // Replace with the path to your destination file
+            string sourcePath = Path.Combine(PXZConstants.RESOURCES_DIRECTORY, "non-empty-scenes.txt"); // Replace with the path to your source file
+            string destinationPath = Path.Combine(PXZConstants.RESOURCES_DIRECTORY, "manifest-world-builder-results.txt"); // Replace with the path to your destination file
             
             if (!File.Exists(destinationPath))
             {


### PR DESCRIPTION
Fixes 

23,-34: Mario House
42,-10: King Trippy's Yacht

Its a bug in PiXYZ fbx exporter, which brough problems on house texturing.  

Depending on the naming of the material (property due to repeated name, because the issue came with the name MATERIAL) references got mixed up. 

Solved by naming randomly each material.