### PR TITLE
fix: correct lod level building

### DIFF
--- a/consumer-server/src/logic/lod-generator.ts
+++ b/consumer-server/src/logic/lod-generator.ts
@@ -33,7 +33,7 @@ export function createLodGeneratorComponent({ logs }: Pick<AppComponents, 'logs'
       sceneLodEntitiesManifestBuilder,
       'false',
       'false',
-      '7000',
+      '7000;500',
       '0'
     ]
     const childProcess = spawn(commandParts[0], commandParts.slice(1))


### PR DESCRIPTION
- Set to build correctly LOD_0 and LOD_1. ATM, only LOD_0 was generated