### PR TITLE
fix: message visibility timeout

### DIFF
--- a/consumer-server/src/adapters/memory-queue.ts
+++ b/consumer-server/src/adapters/memory-queue.ts
@@ -25,5 +25,5 @@ export function createMemoryQueueAdapter(): QueueComponent {
     queue.delete(receiptHandle)
   }
 
-  return { send, receiveSingleMessage, deleteMessage }
+  return { send, receiveSingleMessage, deleteMessage, increaseMessageVisibility: async () => {} }
 }

--- a/consumer-server/src/adapters/sqs.ts
+++ b/consumer-server/src/adapters/sqs.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeMessageVisibilityCommand,
   DeleteMessageCommand,
   Message,
   ReceiveMessageCommand,
@@ -49,9 +50,20 @@ export async function createSqsAdapter(endpoint: string): Promise<QueueComponent
     await client.send(deleteCommand)
   }
 
+  async function increaseMessageVisibility(receiptHandle: string): Promise<void> {
+    await client.send(
+      new ChangeMessageVisibilityCommand({
+        QueueUrl: endpoint,
+        ReceiptHandle: receiptHandle,
+        VisibilityTimeout: 120
+      })
+    )
+  }
+
   return {
     send,
     receiveSingleMessage,
-    deleteMessage
+    deleteMessage,
+    increaseMessageVisibility
   }
 }

--- a/consumer-server/src/types.ts
+++ b/consumer-server/src/types.ts
@@ -77,6 +77,7 @@ export type QueueComponent = {
   send(message: QueueMessage): Promise<void>
   receiveSingleMessage(): Promise<Message[]>
   deleteMessage(receiptHandle: string): Promise<void>
+  increaseMessageVisibility(receiptHandle: string): Promise<void>
 }
 
 export type QueueWorker = IBaseComponent

--- a/consumer-server/test/components.ts
+++ b/consumer-server/test/components.ts
@@ -44,7 +44,8 @@ async function initComponents(): Promise<TestComponents> {
   const queue: QueueComponent = {
     deleteMessage: jest.fn(),
     receiveSingleMessage: jest.fn(),
-    send: jest.fn()
+    send: jest.fn(),
+    increaseMessageVisibility: jest.fn()
   }
   const messageConsumer: QueueWorker = {
     start: jest.fn(),

--- a/consumer-server/test/unit/message-processor.spec.ts
+++ b/consumer-server/test/unit/message-processor.spec.ts
@@ -247,7 +247,8 @@ function getMessageProcessorMockComponents() {
     queue: {
       send: jest.fn(),
       receiveSingleMessage: jest.fn(),
-      deleteMessage: jest.fn()
+      deleteMessage: jest.fn(),
+      increaseMessageVisibility: jest.fn()
     },
     lodGenerator: {
       generate: jest.fn()


### PR DESCRIPTION
On long-processing messages, the visibility timeout of the message expires before it can be removed from the queue, causing the following error:

`Value AQEBpNt9mW8ZihOXjghcsMO9+omrKiigYgTNlE8ztQQTrm1LVTRoNEGAu6sZOBUfwgHT+RqgMKN7aBrQip1Ad85ED0AGij8DpiLxaHcdqzhSoSfs+48UUWA17fqw8RJVXBmrEO5fmcaDXwIM1Vc+twdIqhZL+5rTwASOA37OBFrpd/M0RauY7eUN3+mwHet2sAVbDj5ruQIjGU/7xIQr6nK4/t8aBfxzAaPHMz/idB7RkFrB25H/IxmcQkP/A9Y1784OMz+7zQW8uiZ+H/2+GA1KINgnVVNbzvAx7uiLiWlV2PZ9CBi4F2QhX3n2aFD/uD2rMgO+a02zPovXPMnNTXDcMRLkqIOz8g/tgdPGAYjlh0UBI5S77e0kwFFQbnQ+4UsPp8GrGQvTRjEholFzU4ftvyDpBQ8M/BbDqxMGTPTwVZc= for parameter ReceiptHandle is invalid. Reason: The receipt handle has expired.`


This PR adds code to catch those cases and manually increase the message visibility timeout so it can be removed from the queue, preventing re-processing.