### PR TITLE
chore: disable culling

### DIFF
--- a/.github/workflows/test-lod-conversion.yml
+++ b/.github/workflows/test-lod-conversion.yml
@@ -14,10 +14,10 @@ jobs:
         include:
           - lodLevelsToTest: ["500", "3"]
             files: "QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_3.fbx"
-            sizes: "1413120"
+            sizes: "1888256"
           - lodLevelsToTest: ["7000;3000;1000;500", "0"]
             files: "QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_0.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_1.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_2.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_3.fbx"
-            sizes: "48934912 2572288 1708032 1413120"
+            sizes: "48934912 7028736 2899968 1888256"
             
     steps:
     - uses: actions/checkout@v2

--- a/DCL_PiXYZ/PXZClient.cs
+++ b/DCL_PiXYZ/PXZClient.cs
@@ -207,7 +207,7 @@ namespace DCL_PiXYZ
             if (pxzParams.LodLevel != 0)
             {
                 modifiers.Add(new PXZDeleteByName(".*collider.*"));
-                modifiers.Add(new PXZRemoveHiddenPartOccurrences());
+                //modifiers.Add(new PXZRemoveHiddenPartOccurrences());
                 modifiers.Add(new PXZDecimator(sceneConversionInfo.SceneImporter.GetSceneBasePointer(), pxzParams.DecimationType,
                     pxzParams.DecimationValue, pxzParams.ParcelAmount, pathHandler));
                 modifiers.Add(new PXZMergeMeshes(pxzParams.LodLevel));


### PR DESCRIPTION
- Temporarly disables PXZ culling while we wait for GPU support