### PR TITLE
chore: Size logging and force deleting folders

### DIFF
--- a/DCL_PiXYZ/PXZClient.cs
+++ b/DCL_PiXYZ/PXZClient.cs
@@ -76,23 +76,28 @@ namespace DCL_PiXYZ
                 FileWriter.WriteToConsole("END SCENE CONVERSION FOR " + currentScene);
                 UpdateConvertedScenesFile(convertedScenes);
             }
-            //TODO (Juani): Clear  resources folder
             DoManifestCleanup(args.DebugMode, pathHandler);
+            ClearResourcesFolder(args.DebugMode, pathHandler);
             pxz.Core.ResetSession();
+        }
+
+        private void ClearResourcesFolder(bool isDebug, SceneConversionPathHandler pathHandler)
+        {
+            if (!isDebug)
+                return;
+            
+            if (Directory.Exists(PXZConstants.RESOURCES_DIRECTORY))
+                Directory.Delete(PXZConstants.RESOURCES_DIRECTORY, true);
+            
         }
 
         private void DoManifestCleanup(bool isDebug, SceneConversionPathHandler pathHandler)
         {
             if (!isDebug)
                 return;
-            
-            if (string.IsNullOrEmpty(pathHandler.ManifestOutputJsonDirectory) 
-                || Directory.Exists(pathHandler.ManifestOutputJsonDirectory)) return;
-            
-            var dir = new DirectoryInfo(pathHandler.ManifestOutputJsonDirectory);
-
-            foreach (var fi in dir.GetFiles())
-                fi.Delete();
+          
+            if (Directory.Exists(pathHandler.ManifestOutputJsonDirectory))
+                Directory.Delete(pathHandler.ManifestOutputJsonDirectory, true);
         }
 
         private async Task DoConversion(PXZConversionParams pxzParams, SceneConversionInfo sceneConversionInfo, string scene, SceneConversionPathHandler pathHandler)

--- a/DCL_PiXYZ/PXZClient.cs
+++ b/DCL_PiXYZ/PXZClient.cs
@@ -83,7 +83,7 @@ namespace DCL_PiXYZ
 
         private void ClearResourcesFolder(bool isDebug, SceneConversionPathHandler pathHandler)
         {
-            if (!isDebug)
+            if (isDebug)
                 return;
             
             if (Directory.Exists(PXZConstants.RESOURCES_DIRECTORY))
@@ -93,7 +93,7 @@ namespace DCL_PiXYZ
 
         private void DoManifestCleanup(bool isDebug, SceneConversionPathHandler pathHandler)
         {
-            if (!isDebug)
+            if (isDebug)
                 return;
           
             if (Directory.Exists(pathHandler.ManifestOutputJsonDirectory))

--- a/DCL_PiXYZ/PXZEntryPoint.cs
+++ b/DCL_PiXYZ/PXZEntryPoint.cs
@@ -16,7 +16,10 @@ namespace DCL_PiXYZ
         private static async Task RunLODGeneration(PXZEntryArgs obj)
         {
             PXZClient pxzClient = new PXZClient();
+            FileWriter.currentScene = obj.SceneToConvert;
+            FileWriter.PrintDriveSize("ON START PROCESS");
             await pxzClient.RunLODBuilder(obj);
+            FileWriter.PrintDriveSize("ON END PROCESS");
         }
         
         public static void CloseApplication(string errorMessage)
@@ -24,6 +27,7 @@ namespace DCL_PiXYZ
             Console.Error.WriteLine(errorMessage);
             Environment.Exit(1);
         }
+        
 
         
     }

--- a/DCL_PiXYZ/Utils/FileWriter.cs
+++ b/DCL_PiXYZ/Utils/FileWriter.cs
@@ -24,7 +24,10 @@ namespace DCL_PiXYZ.Utils
         {
             DriveInfo[] allDrives = DriveInfo.GetDrives();
             foreach (DriveInfo d in allDrives)
-                WriteToConsole($"{message} Drive {d.Name} - Total: {ConvertToGB(d.TotalSize)} GB, Available: {ConvertToGB(d.AvailableFreeSpace)} GB, Free: {ConvertToGB(d.TotalFreeSpace)} GB");
+            {
+                if(d.IsReady)
+                    WriteToConsole($"{message} Drive {d.Name} - Total: {ConvertToGB(d.TotalSize)} GB, Available: {ConvertToGB(d.AvailableFreeSpace)} GB, Free: {ConvertToGB(d.TotalFreeSpace)} GB");
+            }
         }
 
         private static double ConvertToGB(long bytes)

--- a/DCL_PiXYZ/Utils/FileWriter.cs
+++ b/DCL_PiXYZ/Utils/FileWriter.cs
@@ -5,6 +5,8 @@ namespace DCL_PiXYZ.Utils
 {
     public class FileWriter
     {
+        public static string currentScene;
+        
         public static void WriteToFile(string message, string fileName)
         {
             using (StreamWriter file = new StreamWriter(fileName, true))
@@ -14,7 +16,23 @@ namespace DCL_PiXYZ.Utils
         public static void WriteToConsole(string message)
         {
             string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
-            Console.WriteLine($"[{timestamp}] {message}");
+            Console.WriteLine($"[{timestamp}] {currentScene} {message}");
         }
+        
+        
+        public static void PrintDriveSize(string message)
+        {
+            DriveInfo[] allDrives = DriveInfo.GetDrives();
+            foreach (DriveInfo d in allDrives)
+                WriteToConsole($"{message} Drive {d.Name} - Total: {ConvertToGB(d.TotalSize)} GB, Available: {ConvertToGB(d.AvailableFreeSpace)} GB, Free: {ConvertToGB(d.TotalFreeSpace)} GB");
+        }
+
+        private static double ConvertToGB(long bytes)
+        {
+            return Math.Round(bytes / (double)(1024 * 1024 * 1024), 2);
+        }
+
+        
+        
     }
 }


### PR DESCRIPTION
- Logs disk size before and after conversion
- Adds the scene coordinate to every log
- Force delete resources folder and manifest folder after conversion