### PR TITLE
fix: main stage LOD

### DIFF
--- a/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLGLTFMesh.cs
+++ b/DCL_PiXYZ/SceneRepositioner/SceneBuilder/Entities/DCLGLTFMesh.cs
@@ -44,7 +44,7 @@ namespace AssetBundleConverter.LODs
             {
                 //TODO (Juani) : This is confusing. If you modify the material and it doesnt fail; but it fails on export of modified model, you wont know it
                 ModifyModelMaterials(modelPath);
-                ExportModifiedModel(modelPath, lodLevel);
+                ExportModifiedModel(modelPath, lodLevel, pathHandler.sceneBasePointer.Contains("-66,-56"));
             }
             catch (Exception e)
             {
@@ -85,7 +85,7 @@ namespace AssetBundleConverter.LODs
                 model.SaveGLTF(modelPath, new WriteSettings(ValidationMode.Skip));
         }
         
-        private void ExportModifiedModel(string modelPath, int lodLevel)
+        private void ExportModifiedModel(string modelPath, int lodLevel, bool forceIgnoreSMR = false)
         {
             var model = ModelRoot.Load(modelPath, new ReadSettings(ValidationMode.Skip));
             var modelRoot = ModelRoot.CreateModel();
@@ -96,7 +96,7 @@ namespace AssetBundleConverter.LODs
                 //If we arent, we dont want to throw a SMR to the merge since PiXYZ offers inconsistent results
                 if (modelLogicalNode.Skin != null)
                 {
-                    if (lodLevel == 0)
+                    if (lodLevel == 0 && !forceIgnoreSMR)
                         throw new Exception("Model has a SMR");
                     else
                         continue;

--- a/DCL_PiXYZ/Utils/SceneConversionPathHandler.cs
+++ b/DCL_PiXYZ/Utils/SceneConversionPathHandler.cs
@@ -13,6 +13,7 @@ public struct SceneConversionPathHandler
         public string ManifestOutputJsonFile;
         public string ManifestOutputJsonDirectory;
         public string ManifestProjectDirectory;
+        public string sceneBasePointer;
 
         private readonly string DefaultOutputPath;
 
@@ -33,11 +34,12 @@ public struct SceneConversionPathHandler
             FailFile = "";
             PolygonCountFile = "";
             FailGLBImporterFile = "";
+            sceneBasePointer = "";
         }
 
         public void SetOutputPath(SceneImporter sceneSceneImporter)
         {
-            string sceneBasePointer = sceneSceneImporter.GetSceneBasePointer();
+            sceneBasePointer = sceneSceneImporter.GetSceneBasePointer();
             DownloadPath = Path.Combine(PXZConstants.RESOURCES_DIRECTORY, sceneBasePointer);
             OutputPath = Path.Combine(DefaultOutputPath, sceneBasePointer);
             ManifestOutputJsonDirectory = Path.Combine(ManifestProjectDirectory, "output-manifests");


### PR DESCRIPTION
For the MVMF2024, the main stage LOD is falling; the output LOD is way larger that the original GLB. 

This is a fix while we find a solution with PiXYZ