### PR TITLE
chore: update pixyz sdk

### DIFF
--- a/.github/workflows/test-lod-conversion.yml
+++ b/.github/workflows/test-lod-conversion.yml
@@ -14,10 +14,10 @@ jobs:
         include:
           - lodLevelsToTest: ["500", "3"]
             files: "QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_3.fbx"
-            sizes: "1613824"
+            sizes: "5382144"
           - lodLevelsToTest: ["7000;3000;1000;500", "0"]
             files: "QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_0.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_1.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_2.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_3.fbx"
-            sizes: "48934912 3428352 2424832 1613824"
+            sizes: "35727600 9031680 7032832 5382144"
             
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-lod-conversion.yml
+++ b/.github/workflows/test-lod-conversion.yml
@@ -14,10 +14,10 @@ jobs:
         include:
           - lodLevelsToTest: ["500", "3"]
             files: "QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_3.fbx"
-            sizes: "5382144"
+            sizes: "5378768"
           - lodLevelsToTest: ["7000;3000;1000;500", "0"]
             files: "QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_0.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_1.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_2.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_3.fbx"
-            sizes: "35727600 9031680 7032832 5382144"
+            sizes: "35727600 9031680 7032832 5378768"
             
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-lod-conversion.yml
+++ b/.github/workflows/test-lod-conversion.yml
@@ -85,7 +85,7 @@ jobs:
         basePath="${GITHUB_WORKSPACE}/publish/OutputDirectoryPath/${{ env.COORDS }}"
         files=(${{ join(matrix.files, ' ') }})
         sizes=(${{ join(matrix.sizes, ' ') }})
-        toleranceB=30000 # 30 KB tolerance
+        toleranceB=40000 # 40 KB tolerance
     
         for i in "${!files[@]}"; do
           filePath="$basePath/${files[$i]}"

--- a/.github/workflows/test-lod-conversion.yml
+++ b/.github/workflows/test-lod-conversion.yml
@@ -85,7 +85,7 @@ jobs:
         basePath="${GITHUB_WORKSPACE}/publish/OutputDirectoryPath/${{ env.COORDS }}"
         files=(${{ join(matrix.files, ' ') }})
         sizes=(${{ join(matrix.sizes, ' ') }})
-        toleranceB=20000 # 10 KB tolerance
+        toleranceB=50000 # 50 KB tolerance
     
         for i in "${!files[@]}"; do
           filePath="$basePath/${files[$i]}"

--- a/.github/workflows/test-lod-conversion.yml
+++ b/.github/workflows/test-lod-conversion.yml
@@ -85,7 +85,7 @@ jobs:
         basePath="${GITHUB_WORKSPACE}/publish/OutputDirectoryPath/${{ env.COORDS }}"
         files=(${{ join(matrix.files, ' ') }})
         sizes=(${{ join(matrix.sizes, ' ') }})
-        toleranceB=50000 # 50 KB tolerance
+        toleranceB=30000 # 30 KB tolerance
     
         for i in "${!files[@]}"; do
           filePath="$basePath/${files[$i]}"

--- a/DCL_PiXYZ/DCL_PiXYZ.csproj
+++ b/DCL_PiXYZ/DCL_PiXYZ.csproj
@@ -32,7 +32,7 @@
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="PiXYZCSharpAPI" Version="2024.1.0.17-win64" />
+      <PackageReference Include="PiXYZCSharpAPI" Version="2024.3.0.8-win64" />
       <PackageReference Include="SharpGLTF.Core" Version="1.0.0-alpha0031" />
       <PackageReference Include="SharpGLTF.Toolkit" Version="1.0.0-alpha0031" />
       <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/DCL_PiXYZ/PXZClient.cs
+++ b/DCL_PiXYZ/PXZClient.cs
@@ -208,6 +208,9 @@ namespace DCL_PiXYZ
             modifiers.Add(new PXZBeginCleanMaterials());
             modifiers.Add(new PXZRepairMesh(models));
             modifiers.Add(new PXZMaterialNameRandomizer());
+            modifiers.Add(new PXZDeleteEmptyOccurrences());
+            modifiers.Add(new PXZDeleteAllAnimations());
+            modifiers.Add(new PXZDeleteInvalidTransforms());
 
             if (pxzParams.LodLevel != 0)
             {
@@ -216,8 +219,14 @@ namespace DCL_PiXYZ
                 modifiers.Add(new PXZDecimator(sceneConversionInfo.SceneImporter.GetSceneBasePointer(), pxzParams.DecimationType,
                     pxzParams.DecimationValue, pxzParams.ParcelAmount, pathHandler));
                 modifiers.Add(new PXZMergeMeshes(pxzParams.LodLevel));
+                
+                //Cleanup after merge
+                modifiers.Add(new PXZDeleteEmptyOccurrences());
+                
+                modifiers.Add(new PXZFlattenHierarchy());
             }
 
+            
             modifiers.Add(new PXZExporter(pxzParams, pathHandler, sceneConversionInfo));
 
             PXZStopwatch stopwatch = new PXZStopwatch();

--- a/DCL_PiXYZ/PXZClient.cs
+++ b/DCL_PiXYZ/PXZClient.cs
@@ -109,7 +109,7 @@ namespace DCL_PiXYZ
                 //Check if they were converted
                 stopwatch.Restart();
                 FileWriter.WriteToConsole($"BEGIN CONVERTING {scene} WITH {pxzParams.DecimationValue}");
-                await ConvertScene(pxzParams, pathHandler, sceneConversionInfo);
+                ConvertScene(pxzParams, pathHandler, sceneConversionInfo);
                 stopwatch.Stop();
 
                 string elapsedTime = string.Format("{0:00}:{1:00}:{2:00}",
@@ -198,7 +198,7 @@ namespace DCL_PiXYZ
             return false; 
         }
 
-        private async Task ConvertScene(PXZConversionParams pxzParams, SceneConversionPathHandler pathHandler, SceneConversionInfo sceneConversionInfo)
+        private void ConvertScene(PXZConversionParams pxzParams, SceneConversionPathHandler pathHandler, SceneConversionInfo sceneConversionInfo)
         {
             SceneRepositioner.SceneRepositioner sceneRepositioner =
                 new SceneRepositioner.SceneRepositioner(pxzParams.SceneContent, pxz, pathHandler, pxzParams.LodLevel);

--- a/DCL_PiXYZ/PiXYZWorflow/PXZDeleteAllAnimations.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZDeleteAllAnimations.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine.Pixyz.API;
+using UnityEngine.Pixyz.Scene;
+
+namespace DCL_PiXYZ
+{
+    public class PXZDeleteAllAnimations : IPXZModifier
+    {
+        public void ApplyModification(PiXYZAPI pxz)
+        {
+            AnimationList animationList = pxz.Scene.ListAnimations();
+            foreach (var animation in animationList.list)
+            {
+                pxz.Scene.DeleteAnimation(animation);
+            }
+        }
+    }
+}

--- a/DCL_PiXYZ/PiXYZWorflow/PXZDeleteEmptyOccurrences.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZDeleteEmptyOccurrences.cs
@@ -1,0 +1,12 @@
+﻿using UnityEngine.Pixyz.API;
+
+namespace DCL_PiXYZ
+{
+    public class PXZDeleteEmptyOccurrences : IPXZModifier
+    {
+        public void ApplyModification(PiXYZAPI pxz)
+        {
+            pxz.Scene.DeleteEmptyOccurrences(pxz.Scene.GetRoot());
+        }
+    }
+}

--- a/DCL_PiXYZ/PiXYZWorflow/PXZDeleteInvalidTransforms.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZDeleteInvalidTransforms.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine.Pixyz.API;
+using UnityEngine.Pixyz.Scene;
+
+namespace DCL_PiXYZ
+{
+    public class PXZDeleteInvalidTransforms : IPXZModifier
+    {
+        public void ApplyModification(PiXYZAPI pxz)
+        {
+            OccurrenceList occs = pxz.Scene.GetFilteredOccurrences("Property(\"Transform\").Matches(\".*nan.*\")") ;
+            pxz.Scene.DeleteOccurrences(occs);
+        }
+    }
+}

--- a/DCL_PiXYZ/PiXYZWorflow/PXZExporter.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZExporter.cs
@@ -28,20 +28,6 @@ namespace DCL_PiXYZ
         public void ApplyModification(PiXYZAPI pxz)
         {
             FileWriter.WriteToConsole($"BEGIN PXZ EXPORT {Path.Combine(path, $"{filename}.fbx")}");
-            //Use it to flatten the hierarchy
-            if (lodLevel != 0)
-            {
-                pxz.Scene.MergeOccurrencesByTreeLevel(new OccurrenceList(new[]
-                {
-                    pxz.Scene.GetRoot()
-                }), 1);*/
-                AnimationList animationList = pxz.Scene.ListAnimations();
-                
-                foreach (var animation in animationList.list)
-                {
-                    pxz.Scene.DeleteAnimation(animation);
-                }
-            }
             pxz.IO.ExportScene(Path.Combine(path, $"{filename}.fbx"), pxz.Scene.GetRoot());
         }
 

--- a/DCL_PiXYZ/PiXYZWorflow/PXZExporter.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZExporter.cs
@@ -34,7 +34,13 @@ namespace DCL_PiXYZ
                 pxz.Scene.MergeOccurrencesByTreeLevel(new OccurrenceList(new[]
                 {
                     pxz.Scene.GetRoot()
-                }), 1);
+                }), 1);*/
+                AnimationList animationList = pxz.Scene.ListAnimations();
+                
+                foreach (var animation in animationList.list)
+                {
+                    pxz.Scene.DeleteAnimation(animation);
+                }
             }
             pxz.IO.ExportScene(Path.Combine(path, $"{filename}.fbx"), pxz.Scene.GetRoot());
         }

--- a/DCL_PiXYZ/PiXYZWorflow/PXZFlattenHierarchy.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZFlattenHierarchy.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine.Pixyz.API;
+using UnityEngine.Pixyz.Scene;
+
+namespace DCL_PiXYZ
+{
+    public class PXZFlattenHierarchy : IPXZModifier
+    {
+        public void ApplyModification(PiXYZAPI pxz)
+        {
+            pxz.Scene.MergeOccurrencesByTreeLevel(new OccurrenceList(new[]
+            {
+                pxz.Scene.GetRoot()
+            }), 1, MergeHiddenPartsMode.Destroy);
+        }
+    }
+}

--- a/DCL_PiXYZ/PiXYZWorflow/PXZMergeMeshes.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZMergeMeshes.cs
@@ -28,6 +28,7 @@ namespace DCL_PiXYZ
             bakeOption = new BakeOption();
             BakeMaps bakeMaps = new BakeMaps();
             bakeMaps.diffuse = true;
+            bakeOption.resolution = 1024;
             this.lodLevel = lodLevel;
             bakeOption.padding = 1;
             bakeOption.textures = bakeMaps;
@@ -84,15 +85,7 @@ namespace DCL_PiXYZ
             if (toMerge.list.Length == 0)
                 return;
 
-            //TODO: What would be the best option here?
-            bakeOption.resolution = 1024;
-            if (lodLevel == 1 && currentVertexCount < 150000)
-                bakeOption.resolution = 512;
-            else if (lodLevel >= 2 && currentVertexCount < 150000)
-                bakeOption.resolution = 256;
-            
             FileWriter.WriteToConsole($"Merging meshes {(isOpaque ? "OPAQUE" : "TRANSPARENT")} {toMerge.list.Length} vertex count {currentVertexCount}");
-
 
             uint combineMeshes = pxz.Scene.MergePartOccurrences(toMerge)[0];
             pxz.Core.SetProperty(combineMeshes, "Name", $"MERGED MESH {index} {(isOpaque ? "OPAQUE" : PXZConstants.FORCED_TRANSPARENT_MATERIAL)}");

--- a/DCL_PiXYZ/PiXYZWorflow/PXZMergeMeshes.cs
+++ b/DCL_PiXYZ/PiXYZWorflow/PXZMergeMeshes.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Threading.Tasks;
-using DCL_PiXYZ.SceneRepositioner.JsonParsing;
 using DCL_PiXYZ.Utils;
 using UnityEngine.Pixyz.Algo;
 using UnityEngine.Pixyz.API;
@@ -28,12 +23,11 @@ namespace DCL_PiXYZ
             opaquesToMerge.list = new uint[]{};
             transparentsToMerge = new OccurrenceList();
             transparentsToMerge.list = new uint[]{};
-            maxVertexCountPerMerge = 200000;
+            maxVertexCountPerMerge = 200_000;
             
             bakeOption = new BakeOption();
             BakeMaps bakeMaps = new BakeMaps();
             bakeMaps.diffuse = true;
-            bakeOption.bakingMethod = BakingMethod.RayOnly;
             this.lodLevel = lodLevel;
             bakeOption.padding = 1;
             bakeOption.textures = bakeMaps;
@@ -99,9 +93,10 @@ namespace DCL_PiXYZ
             
             FileWriter.WriteToConsole($"Merging meshes {(isOpaque ? "OPAQUE" : "TRANSPARENT")} {toMerge.list.Length} vertex count {currentVertexCount}");
 
-            
-            uint combineMeshes = pxz.Algo.CombineMeshes(toMerge, bakeOption);
+
+            uint combineMeshes = pxz.Scene.MergePartOccurrences(toMerge)[0];
             pxz.Core.SetProperty(combineMeshes, "Name", $"MERGED MESH {index} {(isOpaque ? "OPAQUE" : PXZConstants.FORCED_TRANSPARENT_MATERIAL)}");
+            pxz.Algo.CombineMaterials(toMerge, bakeOption);
 
             FileWriter.WriteToConsole("Copying Material");
             //Apply a copy of the material not to lose the reference
@@ -114,7 +109,6 @@ namespace DCL_PiXYZ
                 pxz.Scene.SetOccurrenceMaterial(combineMeshes,copyMaterial);
                 FileWriter.WriteToConsole("Setting Material");
             }
-
         }
 
 


### PR DESCRIPTION
- Updates the PXZ SDK to version `2024.3.0.8-win64`
- Forces textures to be 1024. They will be resized at ABConverter level
- Adds `PXZDeleteEmptyOccurences` to clean the model hierarchy
-  Add `PXZDeleteInvalidTransforms` to remove invalid transforms from the merge operation
- Takes responsibilities out of `PXZExporter`

### Validated results

GP: Old Vs New for LOD_0

![image](https://github.com/user-attachments/assets/f666ff24-256a-4ecb-b8c7-1226deec2a99)

Scenes previously renderered as black on LOD_1 are now colored correctly

bafkreibfbkbcsbcdjw5xphqrfi3ljo34inumnvvtdaga5en4eoftqqkx2a_1
![image](https://github.com/user-attachments/assets/8d37ae9e-5bdc-4eee-a7f3-3f14aa17594b)

bafkreiey2hcq2be726i5uymqjnxf2ty7w72nyvzbkldet345aofs4b6fvm_1
![image](https://github.com/user-attachments/assets/308dbaea-525d-4c23-87f4-43c9a5987951)

QmPgan9voZAaBZzpMz8nBUhHb5jWLGuuiBhddqQQMSfGWG_1
![image](https://github.com/user-attachments/assets/a380dd9e-428d-4fe3-8625-ab38617b9ca5)

QmRHyMyjF83HzeagrLWb3fiRQaJK7vx5r4gyqPbtEboKMx_1
![image](https://github.com/user-attachments/assets/c861988f-d36f-4d1f-871d-142b92a5f2f5)

QmSVf9w4aU9vqafdB9uBuTqwQozMPA8w21UbQ8pfQdpdrp_1
![image](https://github.com/user-attachments/assets/037cdd37-4346-4226-958c-2f9ae3b5c735)

QmVnYgNqRQWogh5tk8Rg8ZrP6zmZRtNrojAoppVmSEN9cB_1
![image](https://github.com/user-attachments/assets/6b3e63bd-bb4b-4682-8d4b-a3e77fadd272)

