### PR TITLE
chore: updating windows-2019 to windows-2022

### DIFF
--- a/.github/workflows/build-consumer-server.yml
+++ b/.github/workflows/build-consumer-server.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.branch_name }}
         lfs: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -10,26 +10,23 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.branch_name }}
         lfs: true
 
     - name: Install Vulkan SDK
-      uses: jakoch/install-vulkan-sdk-action@v1.0.0
+      uses: jakoch/install-vulkan-sdk-action@v1.2.5
       with:
         vulkan_version: 1.3.268.0
         optional_components: com.lunarg.vulkan.vma
         install_runtime: true
         cache: true
+        stripdown: true
         destination: ${{ github.workspace }}/vulkan-sdt
 
-    - name: Get latest commit SHA of the branch
-      id: get_commit_sha
-      run: echo "::set-output name=sha::$(git rev-parse HEAD)"
-
     - name: Checkout NuGet PiXYZ package
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'decentraland/PiXYZ-NuGetPackage'
         token: ${{ secrets.PAT_NUGET_TOKEN }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - name: Checkout code

--- a/.github/workflows/dispatch-lod-conversion.yml
+++ b/.github/workflows/dispatch-lod-conversion.yml
@@ -20,12 +20,12 @@ jobs:
   build-and-run:
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         lfs: true
             
     - name: Checkout NuGet PiXYZ package
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'decentraland/PiXYZ-NuGetPackage'
         token: ${{ secrets.PAT_NUGET_TOKEN }}
@@ -33,30 +33,31 @@ jobs:
         lfs: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: 8.0.x
 
     - name: Publish with dotnet
-      run:  dotnet publish -c Release -r win10-x64 -o ./publish --self-contained true 
+      run:  dotnet publish -c Release -o ./publish --self-contained true
       
     - name: Copy manifest builder to publish directory
       run: |
-        Copy-Item -Path "${{ github.workspace }}\DCL_PiXYZ\bin\Release\netcoreapp3.1\win10-x64\scene-lod-entities-manifest-builder" -Destination "${{ github.workspace }}\publish\scene-lod-entities-manifest-builder" -Recurse
+        Copy-Item -Path "${{ github.workspace }}\DCL_PiXYZ\bin\Release\net8.0\win-x64\scene-lod-entities-manifest-builder" -Destination "${{ github.workspace }}\publish\scene-lod-entities-manifest-builder" -Recurse
       shell: pwsh
       
     - name: Copy road coordinates
       run: |
-          Copy-Item -Path "${{ github.workspace }}\DCL_PiXYZ\bin\Release\netcoreapp3.1\win10-x64\SingleParcelRoadCoordinates.json" -Destination "${{ github.workspace }}\publish"
-      shell: pwsh 
+          Copy-Item -Path "${{ github.workspace }}\DCL_PiXYZ\bin\Release\net8.0\win-x64\SingleParcelRoadCoordinates.json" -Destination "${{ github.workspace }}\publish"
+      shell: pwsh
 
     - name: Install Vulkan SDK
-      uses: jakoch/install-vulkan-sdk-action@v1.0.0
+      uses: jakoch/install-vulkan-sdk-action@v1.2.5
       with:
         vulkan_version: 1.3.268.0
         optional_components: com.lunarg.vulkan.vma
         install_runtime: true
         cache: true
+        stripdown: true
         destination: ${{ github.workspace }}/vulkan-sdt
 
     - name: Move Vulkan DLL to output directory
@@ -65,7 +66,7 @@ jobs:
       shell: bash
 
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '18.14.2'
 

--- a/.github/workflows/dispatch-lod-conversion.yml
+++ b/.github/workflows/dispatch-lod-conversion.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-and-run:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - name: Checkout code

--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -11,22 +11,23 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.branch_name }}
         lfs: true
 
     - name: Install Vulkan SDK
-      uses: jakoch/install-vulkan-sdk-action@v1.0.0
+      uses: jakoch/install-vulkan-sdk-action@v1.2.5
       with:
         vulkan_version: 1.3.268.0
         optional_components: com.lunarg.vulkan.vma
         install_runtime: true
         cache: true
+        stripdown: true
         destination: ${{ github.workspace }}/vulkan-sdt
 
     - name: Checkout NuGet PiXYZ package
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'decentraland/PiXYZ-NuGetPackage'
         token: ${{ secrets.PAT_NUGET_TOKEN }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - name: Checkout code

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -11,22 +11,23 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.branch_name }}
         lfs: true
 
     - name: Install Vulkan SDK
-      uses: jakoch/install-vulkan-sdk-action@v1.0.0
+      uses: jakoch/install-vulkan-sdk-action@v1.2.5
       with:
         vulkan_version: 1.3.268.0
         optional_components: com.lunarg.vulkan.vma
         install_runtime: true
         cache: true
+        stripdown: true
         destination: ${{ github.workspace }}/vulkan-sdt
 
     - name: Checkout NuGet PiXYZ package
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'decentraland/PiXYZ-NuGetPackage'
         token: ${{ secrets.PAT_NUGET_TOKEN }}

--- a/.github/workflows/test-lod-conversion.yml
+++ b/.github/workflows/test-lod-conversion.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-run:
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       COORDS: "-55,1"  # Define coordinates as an environment variable    
     strategy:

--- a/.github/workflows/test-lod-conversion.yml
+++ b/.github/workflows/test-lod-conversion.yml
@@ -14,15 +14,15 @@ jobs:
         include:
           - lodLevelsToTest: ["7000;3000;1000;500", "0"]
             files: "QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_0.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_1.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_2.fbx QmTpsFiaJVPv5mU6ERBzkDcZ39Lyq9sEfiLw9Ep3VQAFgK_3.fbx"
-            sizes: "35727600 9031680 7032832 5378768"
+            sizes: "35727600 9031680 7032832 5208112"
             
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         lfs: true
             
     - name: Checkout NuGet PiXYZ package
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'decentraland/PiXYZ-NuGetPackage'
         token: ${{ secrets.PAT_NUGET_TOKEN }}
@@ -30,30 +30,31 @@ jobs:
         lfs: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: 8.0.x
 
     - name: Publish with dotnet
-      run:  dotnet publish -c Release -r win10-x64 -o ./publish --self-contained true 
+      run:  dotnet publish -c Release -o ./publish --self-contained true
       
     - name: Copy manifest builder to publish directory
       run: |
-        Copy-Item -Path "${{ github.workspace }}\DCL_PiXYZ\bin\Release\netcoreapp3.1\win10-x64\scene-lod-entities-manifest-builder" -Destination "${{ github.workspace }}\publish\scene-lod-entities-manifest-builder" -Recurse
+        Copy-Item -Path "${{ github.workspace }}\DCL_PiXYZ\bin\Release\net8.0\win-x64\scene-lod-entities-manifest-builder" -Destination "${{ github.workspace }}\publish\scene-lod-entities-manifest-builder" -Recurse
       shell: pwsh
       
     - name: Copy road coordinates
       run: |
-          Copy-Item -Path "${{ github.workspace }}\DCL_PiXYZ\bin\Release\netcoreapp3.1\win10-x64\SingleParcelRoadCoordinates.json" -Destination "${{ github.workspace }}\publish"
-      shell: pwsh 
+          Copy-Item -Path "${{ github.workspace }}\DCL_PiXYZ\bin\Release\net8.0\win-x64\SingleParcelRoadCoordinates.json" -Destination "${{ github.workspace }}\publish"
+      shell: pwsh
 
     - name: Install Vulkan SDK
-      uses: jakoch/install-vulkan-sdk-action@v1.0.0
+      uses: jakoch/install-vulkan-sdk-action@v1.2.5
       with:
         vulkan_version: 1.3.268.0
         optional_components: com.lunarg.vulkan.vma
         install_runtime: true
         cache: true
+        stripdown: true
         destination: ${{ github.workspace }}/vulkan-sdt
 
     - name: Move Vulkan DLL to output directory
@@ -62,7 +63,7 @@ jobs:
       shell: bash
 
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '18.14.2'
 

--- a/DCL_PiXYZ/DCL_PiXYZ.csproj
+++ b/DCL_PiXYZ/DCL_PiXYZ.csproj
@@ -2,7 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -23,6 +24,44 @@
         <Copy SourceFiles="@(SceneLODManifestFolder)" DestinationFiles="@(SceneLODManifestFolder->'$(OutputPath)%(TargetPath)')" SkipUnchangedFiles="true" />
         <Copy SourceFiles="@(RoadCoordinatesFolder)" DestinationFiles="@(RoadCoordinatesFolder->'$(OutputPath)%(TargetPath)')" SkipUnchangedFiles="true" />
         <Copy SourceFiles="@(LicenseFileFolder)" DestinationFiles="@(LicenseFileFolder->'$(OutputPath)%(TargetPath)')" SkipUnchangedFiles="true" />
+    </Target>
+
+    <!--
+      The following two targets are required due to the PiXYZCSharpAPI NuGet package
+      including multiple files with duplicate names and extensions in different locations.
+      These cause publish-time conflicts (error NETSDK1152) when using .NET 8.0,
+      so we explicitly remove the duplicate or conflicting files before the ComputeFilesToPublish target.
+    -->
+
+    <Target Name="RemoveDuplicatePublishFiles" BeforeTargets="ComputeFilesToPublish">
+        <ItemGroup>
+            <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
+              Condition=" '%(ResolvedFileToPublish.PathInPackage)' != '' and (
+                '%(ResolvedFileToPublish.PathInPackage)' == 'runtimes/win-x64/native/podofo.dll' or
+                '%(ResolvedFileToPublish.PathInPackage)' == 'runtimes/win-x64/native/plugins/OdaImportPlugin/tbb12.dll' or
+                '%(ResolvedFileToPublish.PathInPackage)' == 'runtimes/win-x64/native/plugins/OdaImportPlugin/xerces-c_3_1.dll' or
+                '%(ResolvedFileToPublish.PathInPackage)' == 'runtimes/win-x64/native/xerces-c_3_1.dll'
+              )" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="RemoveUSDConflicts" BeforeTargets="ComputeFilesToPublish">
+        <ItemGroup>
+            <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
+              Condition=" '%(ResolvedFileToPublish.PathInPackage)' != '' and (
+                (
+                  ('%(ResolvedFileToPublish.Filename)' == 'schema' or
+                  '%(ResolvedFileToPublish.Filename)' == 'generatedSchema') and
+                  '%(ResolvedFileToPublish.Extension)' == '.usda'
+                ) or
+                (
+                  '%(ResolvedFileToPublish.Filename)' == 'plugInfo' and
+                  '%(ResolvedFileToPublish.Extension)' == '.json'
+                ) or
+                '%(ResolvedFileToPublish.Extension)' == '.txt' or
+                '%(ResolvedFileToPublish.Extension)' == '.TXT'
+              )" />
+        </ItemGroup>
     </Target>
 
     <ItemGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY consumer-server .
 RUN yarn build
 
 #build the dotnet app
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-nanoserver-1809 as dotnet-build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2022 as dotnet-build
 
 WORKDIR /build
 
@@ -58,12 +58,12 @@ COPY ${PIXYZ_PACKAGE} ./PiXYZ-NuGetPackage/
 
 COPY PiXYZ.sln ./
 
-RUN dotnet publish -c Release -r win10-x64 -o ./publish --self-contained true
+RUN dotnet publish -c Release -o ./publish --self-contained true
 ARG VULKAN_DLL_PATH
 COPY ${VULKAN_DLL_PATH} ./publish/vulkan-1.dll
 
 # bundle all apps
-FROM mcr.microsoft.com/windows:ltsc2022
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 RUN powershell -Command Set-ExecutionPolicy RemoteSigned -Force
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # prepare base image for TS projects
-FROM mcr.microsoft.com/windows/servercore:ltsc2019 as base
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 as base
 
 ADD https://aka.ms/vs/16/release/vc_redist.x64.exe C:\\vc_redist.x64.exe
 RUN C:\\vc_redist.x64.exe /quiet /install
@@ -63,7 +63,7 @@ ARG VULKAN_DLL_PATH
 COPY ${VULKAN_DLL_PATH} ./publish/vulkan-1.dll
 
 # bundle all apps
-FROM mcr.microsoft.com/windows:ltsc2019
+FROM mcr.microsoft.com/windows:ltsc2022
 
 RUN powershell -Command Set-ExecutionPolicy RemoteSigned -Force
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY consumer-server .
 RUN yarn build
 
 #build the dotnet app
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as dotnet-build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-nanoserver-1809 as dotnet-build
 
 WORKDIR /build
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "3.1.0",
-    "rollForward": "latestMinor",
-    "allowPrerelease": false
-  }
-}


### PR DESCRIPTION
GitHub is deprecating the windows-2019 runner image starting June 1, 2025, with complete removal by June 30, 2025. Any workflow still referencing this image will fail on GitHub-hosted runners after that date.