### PR TITLE
fix: add opengl support for Windows 2022

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,6 +25,12 @@ jobs:
         stripdown: true
         destination: ${{ github.workspace }}/vulkan-sdt
 
+    - name: Copy OpenGL DLLs to workspace
+      shell: pwsh
+      run: |
+        Copy-Item -Path "C:\Windows\System32\OPENGL32.dll" -Destination "${{ github.workspace }}\OPENGL32.dll"
+        Copy-Item -Path "C:\Windows\System32\GLU32.dll" -Destination "${{ github.workspace }}\GLU32.dll"
+
     - name: Checkout NuGet PiXYZ package
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -26,6 +26,12 @@ jobs:
         stripdown: true
         destination: ${{ github.workspace }}/vulkan-sdt
 
+    - name: Copy OpenGL DLLs to workspace
+      shell: pwsh
+      run: |
+        Copy-Item -Path "C:\Windows\System32\OPENGL32.dll" -Destination "${{ github.workspace }}\OPENGL32.dll"
+        Copy-Item -Path "C:\Windows\System32\GLU32.dll" -Destination "${{ github.workspace }}\GLU32.dll"
+
     - name: Checkout NuGet PiXYZ package
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -26,6 +26,12 @@ jobs:
         stripdown: true
         destination: ${{ github.workspace }}/vulkan-sdt
 
+    - name: Copy OpenGL DLLs to workspace
+      shell: pwsh
+      run: |
+        Copy-Item -Path "C:\Windows\System32\OPENGL32.dll" -Destination "${{ github.workspace }}\OPENGL32.dll"
+        Copy-Item -Path "C:\Windows\System32\GLU32.dll" -Destination "${{ github.workspace }}\GLU32.dll"
+
     - name: Checkout NuGet PiXYZ package
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
- Added steps to copy OpenGL DLLs (OPENGL32.dll and GLU32.dll) into the Docker build process for Windows 2022 images
- Updated the Dockerfile and workflows to include these DLLs
- Cleaned up some install and environment variable commands